### PR TITLE
New block: Glossary Term

### DIFF
--- a/app/js/app/directives/content_editor.js
+++ b/app/js/app/directives/content_editor.js
@@ -36,7 +36,8 @@ define([
 	"jsx!./react_classes/TabsBlock",
 	"jsx!./react_classes/AccordionBlock",
 	"jsx!./react_classes/UnknownBlock",
-	"jsx!./react_classes/Block"
+	"jsx!./react_classes/Block",
+	"jsx!./react_classes/GlossaryTermBlock"
 	], function(React, $, cmjs, sd, sdt, mjc,
 		_Title,
 		_Tags,
@@ -68,7 +69,8 @@ define([
 		_TabsBlock,
 		_AccordionBlock,
 		_UnknownBlock,
-		_Block
+		_Block,
+		_GlossaryTermBlock
 	) {
 
 /////////////////////////////////
@@ -195,6 +197,8 @@ define([
 
 	var QuestionBlock = _QuestionBlock(ContentEditor, Block, VariantBlock, ContentChildren, ContentValueOrChildren, TabsBlock, ParsonsItemBlock, ParsonsChoiceBlock);
 
+	var GlossaryTermBlock = _GlossaryTermBlock(ContentEditor, Block, ContentBlock);
+
 /////////////////////////////////
 // Register Types
 /////////////////////////////////
@@ -236,6 +240,7 @@ define([
 	typeMap["isaacItemQuestion"] = QuestionBlock;
 	typeMap["isaacParsonsQuestion"] = QuestionBlock;
 	typeMap["emailTemplate"] = EmailTemplateBlock;
+	typeMap["glossaryTerm"] = GlossaryTermBlock;
 
 
 /////////////////////////////////

--- a/app/js/app/directives/react_classes/GlossaryTermBlock.js
+++ b/app/js/app/directives/react_classes/GlossaryTermBlock.js
@@ -10,6 +10,9 @@ define(["react", "jquery"], function(React,$) {
                 var oldDoc = this.props.doc;
                 var newDoc = $.extend({}, oldDoc);
                 newDoc.value = e.target.value;
+                if (newDoc.autoId) {
+                    newDoc.id = e.target.value.toLowerCase().replace(/[^\w]/g, '-');
+                }
                 this.onDocChange(this, oldDoc, newDoc);
             },
 
@@ -17,6 +20,23 @@ define(["react", "jquery"], function(React,$) {
                 var oldDoc = this.props.doc;
                 var newDoc = $.extend({}, oldDoc);
                 newDoc.explanation = newVal;
+                this.onDocChange(this, oldDoc, newDoc);
+            },
+
+            onAutoIdToggle: function(c, oldVal, newVal) {
+                var oldDoc = this.props.doc;
+                var newDoc = $.extend({}, oldDoc);
+                newDoc.autoId = !newDoc.autoId;
+                if (newDoc.autoId) {
+                    newDoc.id = newDoc.value.toLowerCase().replace(/[^\w]/g, '-');
+                }
+                this.onDocChange(this, oldDoc, newDoc);
+            },
+
+            onIdChange: function(c, oldVal, newVal) {
+                var oldDoc = this.props.doc;
+                var newDoc = $.extend({}, oldDoc);
+                newDoc.id = c.target.value.toLowerCase().replace(/[^\w]/g, '-');
                 this.onDocChange(this, oldDoc, newDoc);
             },
 
@@ -30,6 +50,9 @@ define(["react", "jquery"], function(React,$) {
             },
 
             render: function() {
+                if (typeof this.props.doc.autoId == 'undefined') {
+                    this.props.doc.autoId = true;
+                }
                 var emptyExplanation = {
                     type: "content",
                     children: [],
@@ -39,7 +62,10 @@ define(["react", "jquery"], function(React,$) {
                     <Block type="glossaryTerm" blockTypeTitle="Glossary term" doc={this.props.doc} onChange={this.onDocChange}>
                         <div className="small-3 columns">
                             <div className="row">
-                                <input type="text" value={this.props.doc.value} onChange={this.onContentChange} placeholder="Glossary term"/>
+                                <input type="text" value={this.props.doc.value} onChange={this.onContentChange} placeholder="Glossary term" />
+                                <input type="checkbox" checked={this.props.doc.autoId} onChange={this.onAutoIdToggle} /><label>Automatic IDs</label>
+                                {this.props.doc.autoId && <p>ID: {this.props.doc.id}</p>}
+                                {!this.props.doc.autoId && <input type="text" value={this.props.doc.id} onChange={this.onIdChange} placeholder="ID" />}
                             </div>
                         </div>
                         <div className="small-9 columns" >

--- a/app/js/app/directives/react_classes/GlossaryTermBlock.js
+++ b/app/js/app/directives/react_classes/GlossaryTermBlock.js
@@ -16,10 +16,10 @@ define(["react", "jquery"], function(React,$) {
                 this.onDocChange(this, oldDoc, newDoc);
             },
 
-            onExplanationChange: function(c, oldVal, newVal) {
+            onExplanationChange: function(e) {
                 var oldDoc = this.props.doc;
                 var newDoc = $.extend({}, oldDoc);
-                newDoc.explanation = newVal;
+                newDoc.explanation.value = e.target.value;
                 this.onDocChange(this, oldDoc, newDoc);
             },
 
@@ -53,11 +53,6 @@ define(["react", "jquery"], function(React,$) {
                 if (typeof this.props.doc.autoId == 'undefined') {
                     this.props.doc.autoId = true;
                 }
-                var emptyExplanation = {
-                    type: "content",
-                    children: [],
-                    encoding: "markdown"
-                };
                 return (
                     <Block type="glossaryTerm" blockTypeTitle="Glossary term" doc={this.props.doc} onChange={this.onDocChange}>
                         <div className="small-3 columns">
@@ -69,7 +64,7 @@ define(["react", "jquery"], function(React,$) {
                             </div>
                         </div>
                         <div className="small-9 columns" >
-                            <ContentBlock type="content" blockTypeTitle="Explanation" doc={this.props.doc.explanation || emptyExplanation} onChange={this.onExplanationChange} />
+                            <textarea value={this.props.doc.explanation.value || ''} rows="6" onChange={this.onExplanationChange}></textarea>
                         </div>
                     </Block>
                 );

--- a/app/js/app/directives/react_classes/GlossaryTermBlock.js
+++ b/app/js/app/directives/react_classes/GlossaryTermBlock.js
@@ -1,0 +1,53 @@
+define(["react", "jquery"], function(React,$) {
+    return function(ContentEditor, Block, ContentBlock) {
+        return React.createClass({
+
+            onDocChange: function(c, oldDoc, newDoc) {
+                this.props.onChange(this, oldDoc, newDoc);
+            },
+
+            onContentChange: function(e) {
+                var oldDoc = this.props.doc;
+                var newDoc = $.extend({}, oldDoc);
+                newDoc.value = e.target.value;
+                this.onDocChange(this, oldDoc, newDoc);
+            },
+
+            onExplanationChange: function(c, oldVal, newVal) {
+                var oldDoc = this.props.doc;
+                var newDoc = $.extend({}, oldDoc);
+                newDoc.explanation = newVal;
+                this.onDocChange(this, oldDoc, newDoc);
+            },
+
+            toggle: function(attribute) {
+                return function() {
+                    var oldDoc = this.props.doc;
+                    var newDoc = $.extend({}, oldDoc);
+                    newDoc[attribute] = !oldDoc[attribute];
+                    this.onDocChange(this, oldDoc, newDoc);
+                }.bind(this);
+            },
+
+            render: function() {
+                var emptyExplanation = {
+                    type: "content",
+                    children: [],
+                    encoding: "markdown"
+                };
+                return (
+                    <Block type="glossaryTerm" blockTypeTitle="Glossary term" doc={this.props.doc} onChange={this.onDocChange}>
+                        <div className="small-3 columns">
+                            <div className="row">
+                                <input type="text" value={this.props.doc.value} onChange={this.onContentChange} placeholder="Glossary term"/>
+                            </div>
+                        </div>
+                        <div className="small-9 columns" >
+                            <ContentBlock type="content" blockTypeTitle="Explanation" doc={this.props.doc.explanation || emptyExplanation} onChange={this.onExplanationChange} />
+                        </div>
+                    </Block>
+                );
+            }
+        })
+    }
+})

--- a/app/js/app/directives/react_classes/UnknownBlock.js
+++ b/app/js/app/directives/react_classes/UnknownBlock.js
@@ -41,6 +41,7 @@ define(["react", "jquery"], function(React,$) {
 								Please choose a block type: <br/>
 								<a onClick={this.chooseType} data-chosen-type="content">content</a>&nbsp; | &nbsp;
 								<a onClick={this.chooseQuestion} data-chosen-type="isaacQuestion">question</a>&nbsp; | &nbsp;
+								<a onClick={this.chooseType} data-chosen-type="glossaryTerm">glossary term</a>&nbsp; | &nbsp;
 								<a onClick={this.chooseType} data-chosen-type="figure">figure</a>&nbsp; | &nbsp;
 								<a onClick={this.chooseType} data-chosen-type="video">video</a>&nbsp; | &nbsp;
 								<a onClick={this.chooseType} data-chosen-type="tabs">tabs</a>&nbsp; | &nbsp;

--- a/app/snippets/content_templates/glossaryTerm.json
+++ b/app/snippets/content_templates/glossaryTerm.json
@@ -1,0 +1,10 @@
+{
+	"encoding": "markdown",
+	"value": "_Enter term here_",
+	"type": "glossaryTerm",
+	"explanation": {
+		"type": "content",
+		"children": [],
+		"encoding": "markdown"
+	}
+}

--- a/app/snippets/content_templates/glossaryTerm.json
+++ b/app/snippets/content_templates/glossaryTerm.json
@@ -1,10 +1,10 @@
 {
 	"encoding": "markdown",
-	"value": "_Enter term here_",
+	"value": "",
 	"type": "glossaryTerm",
 	"explanation": {
 		"type": "content",
-		"children": [],
+		"value": "",
 		"encoding": "markdown"
 	}
 }


### PR DESCRIPTION
Add these inside Concept pages (might add a dedicated page type in the future) and brace for content errors, because the API does not know about these.

* 04fcd62 Allow editing of glossary terms IDs and add the option to have them auto-generated
* 2cdb6a8 Merge remote-tracking branch 'origin/master' into feature/glossary-terms
* 9e9d618 New block: Glossary Term
* 2cdb6a8 Merge remote-tracking branch 'origin/master' into feature/glossary-terms
* 0e96f78 Change content block to simple textarea element for glossary terms