### PR TITLE
Add disableIndentation checkbox for Parsons problems

### DIFF
--- a/app/js/app/directives/react_classes/QuestionBlock.js
+++ b/app/js/app/directives/react_classes/QuestionBlock.js
@@ -456,7 +456,7 @@ define(["react", "jquery"], function(React,$) {
 										</div>
 									</div>
 									<div className="row" style={{display: this.props.doc.type === "isaacParsonsQuestion" ? "block" : "none"}}>
-										<div ref="disableIndentationCheckbox" className="small-6 small-offset-4 columns">
+										<div ref="disableIndentationCheckbox" className="small-6 columns">
 											<label><input type="checkbox" checked={this.props.doc.disableIndentation} onChange={this.onCheckboxChange.bind(this, "disableIndentation")} /> Disable indentation</label>
 										</div>
 									</div>

--- a/app/js/app/directives/react_classes/QuestionBlock.js
+++ b/app/js/app/directives/react_classes/QuestionBlock.js
@@ -455,6 +455,11 @@ define(["react", "jquery"], function(React,$) {
 											<input type="checkbox" checked={this.props.doc.multiLineEntry} onChange={this.onCheckboxChange.bind(this, "multiLineEntry")} /> Multi-line
 										</div>
 									</div>
+									<div className="row" style={{display: this.props.doc.type === "isaacParsonsQuestion" ? "block" : "none"}}>
+										<div ref="disableIndentationCheckbox" className="small-6 small-offset-4 columns">
+											<label><input type="checkbox" checked={this.props.doc.disableIndentation} onChange={this.onCheckboxChange.bind(this, "disableIndentation")} /> Disable indentation</label>
+										</div>
+									</div>
 								</div>
 								<div className="small-6 columns">
 									<select value={this.props.doc.type} onChange={this.type_Change}>


### PR DESCRIPTION
The indentation of the checkbox is OKish but is it necessary? I can see it's good to have for numeric questions and every other checkbox is a copy-paste job from that one, but isn't it better to have it aligned somewhere else?