### PR TITLE
Add alt text default for video and soft remove value

### DIFF
--- a/app/js/app/directives/react_classes/VideoBlock.js
+++ b/app/js/app/directives/react_classes/VideoBlock.js
@@ -6,10 +6,10 @@ define(["react", "jquery"], function(React,$) {
 				this.props.onChange(this, oldDoc, newDoc);
 			},
 
-			onCaptionChange: function(c, oldVal, newVal, oldChildren, newChildren) {
+			onAltTextChange: function(c, oldVal, newVal, oldChildren, newChildren) {
 				var oldDoc = this.props.doc;
 				var newDoc = $.extend({}, this.props.doc);
-				newDoc.value = newVal;
+				newDoc.altText = newVal;
 				newDoc.children = newChildren;
 
 				this.onDocChange(this, oldDoc, newDoc);
@@ -17,7 +17,7 @@ define(["react", "jquery"], function(React,$) {
 
 			render: function() {
 
-				var optionalCaption = <ContentValueOrChildren value={this.props.doc.value} children={this.props.doc.children} encoding={this.props.doc.encoding} onChange={this.onCaptionChange}/>;
+				var optionalAltText = <ContentValueOrChildren value={this.props.doc.altText} children={this.props.doc.children} encoding={this.props.doc.encoding} onChange={this.onAltTextChange}/>;
 
 				return (
 					<Block type="video" blockTypeTitle="Video" doc={this.props.doc} onChange={this.onDocChange}>
@@ -26,7 +26,7 @@ define(["react", "jquery"], function(React,$) {
 								Video src: {this.props.doc.src}
 							</div>
 							<div className="small-6 columns">
-								{optionalCaption}
+								{optionalAltText}
 							</div>
 						</div>
 					</Block>

--- a/app/js/app/directives/react_classes/VideoBlock.js
+++ b/app/js/app/directives/react_classes/VideoBlock.js
@@ -6,27 +6,32 @@ define(["react", "jquery"], function(React,$) {
 				this.props.onChange(this, oldDoc, newDoc);
 			},
 
-			onAltTextChange: function(c, oldVal, newVal, oldChildren, newChildren) {
+			onAltTextChange: function(e) {
+
+				this.setState({
+					altText: e.target.value
+				});
+
 				var oldDoc = this.props.doc;
 				var newDoc = $.extend({}, this.props.doc);
-				newDoc.altText = newVal;
-				newDoc.children = newChildren;
+				newDoc.altText = e.target.value;
 
 				this.onDocChange(this, oldDoc, newDoc);
 			},
 
 			render: function() {
 
-				var optionalAltText = <ContentValueOrChildren value={this.props.doc.altText} children={this.props.doc.children} encoding={this.props.doc.encoding} onChange={this.onAltTextChange}/>;
-
 				return (
 					<Block type="video" blockTypeTitle="Video" doc={this.props.doc} onChange={this.onDocChange}>
 						<div className="row">
-							<div className="small-6 columns text-center">
+							<div className="small-4 columns text-center">
 								Video src: {this.props.doc.src}
 							</div>
-							<div className="small-6 columns">
-								{optionalAltText}
+							<div className="small-3 columns text-right">
+								Alt Text:
+							</div>
+							<div className="small-5 columns">
+								<input type="text" placeholder="Enter alt text" value={this.props.doc.altText} onChange={this.onAltTextChange} />
 							</div>
 						</div>
 					</Block>

--- a/app/snippets/content_templates/video.json
+++ b/app/snippets/content_templates/video.json
@@ -2,6 +2,5 @@
 	"type": "video",
 	"encoding": "markdown",
 	"altText": "_Add video alt text here_",
-	"value": "",
 	"src": "https://www.youtube.com/watch?v=<video_id>"
 }

--- a/app/snippets/content_templates/video.json
+++ b/app/snippets/content_templates/video.json
@@ -1,6 +1,7 @@
 {
 	"type": "video",
 	"encoding": "markdown",
-	"value": "_Add video caption here_",
+	"altText": "_Add video alt text here_",
+	"value": "",
 	"src": "https://www.youtube.com/watch?v=<video_id>"
 }

--- a/app/snippets/content_templates/video.json
+++ b/app/snippets/content_templates/video.json
@@ -1,6 +1,5 @@
 {
 	"type": "video",
 	"encoding": "markdown",
-	"altText": "_Add video alt text here_",
 	"src": "https://www.youtube.com/watch?v=<video_id>"
 }


### PR DESCRIPTION
- Add altText as the in page editable video accompaniment.
- Value still exists but isn't alterable outside of the metadata, stop extra being added by accident but keeps existing for transfer to altText 