### PR TITLE
Add displayUnit to numeric questions

### DIFF
--- a/app/js/app/directives/react_classes/QuestionBlock.js
+++ b/app/js/app/directives/react_classes/QuestionBlock.js
@@ -90,6 +90,20 @@ define(["react", "jquery"], function(React,$) {
 				this.onDocChange(this, oldDoc, newDoc);
 			},
 
+			onDisplayUnitChange: function(e) {
+
+				var oldDoc = this.props.doc;
+				var newDoc = $.extend({}, oldDoc);
+				if (!e.target.value.replace(/\s/g, '').length) {
+					newDoc.displayUnit = null;
+				} else {
+					newDoc.displayUnit = e.target.value;
+					newDoc.requireUnits = false;
+				}
+
+				this.onDocChange(this, oldDoc, newDoc);
+			},
+
 
 			onTitleChange: function(e) {
 
@@ -110,12 +124,15 @@ define(["react", "jquery"], function(React,$) {
 				if (newType == "isaacNumericQuestion" && !newDoc.hasOwnProperty("requireUnits")) {
 					// Add the default value if it is missing
 					newDoc.requireUnits = true;
+					newDoc.displayUnit = null;
 				} else if (newType == "isaacMultiChoiceQuestion" && !newDoc.hasOwnProperty("randomiseChoices")) {
 					// Add the default value if it is missing
 					newDoc.randomiseChoices = true;
 				} else {
 					// Remove the requireUnits property as it is no longer applicable to this type of question
 					delete newDoc.requireUnits;
+					// Remove the displayUnit property as it is no longer applicable to this type of question
+					delete newDoc.displayUnit;
 					// Remove the randomiseChoices property as it is no longer applicable to this type of question
 					delete newDoc.randomiseChoices;
 				}
@@ -129,7 +146,12 @@ define(["react", "jquery"], function(React,$) {
 				// newVal must be a doc
 				var oldDoc = this.props.doc;
 				var newDoc = $.extend({}, oldDoc);
-				newDoc[key] = e.target.checked;
+				if (key === "requireUnits" && e.target.checked) {
+					newDoc[key] = e.target.checked;
+					newDoc["displayUnit"] = null;
+				} else {
+					newDoc[key] = e.target.checked;
+				}
 
 				this.onDocChange(this, oldDoc, newDoc);
 			},
@@ -441,10 +463,17 @@ define(["react", "jquery"], function(React,$) {
 										</div>
 									</div>
 									<div className="row" style={{display: this.props.doc.type == "isaacNumericQuestion" ? "block" : "none"}}>
-										<div ref="requireUnitsCheckbox" className="small-6 small-offset-6 columns">
+										<div className="small-3 columns text-right">
+											Display unit:
+										</div>
+										<div className="small-3 columns">
+											<input type="text" value={this.props.doc.displayUnit} onChange={this.onDisplayUnitChange}/>
+										</div>
+										<div ref="requireUnitsCheckbox" className="small-6 columns">
 											<label><input type="checkbox" checked={this.props.doc.requireUnits} onChange={this.onCheckboxChange.bind(this, "requireUnits")} />Require Units</label>
 										</div>
 									</div>
+
 									<div className="row" style={{display: this.props.doc.type == "isaacMultiChoiceQuestion" ? "block" : "none"}}>
 										<div ref="randomiseChoicesCheckbox" className="small-6 small-offset-6 columns">
 											<label><input type="checkbox" checked={this.props.doc.randomiseChoices} onChange={this.onCheckboxChange.bind(this, "randomiseChoices")} />Randomise Choices</label>

--- a/app/js/app/directives/react_classes/QuestionBlock.js
+++ b/app/js/app/directives/react_classes/QuestionBlock.js
@@ -147,11 +147,9 @@ define(["react", "jquery"], function(React,$) {
 				var oldDoc = this.props.doc;
 				var newDoc = $.extend({}, oldDoc);
 				if (key === "requireUnits" && e.target.checked) {
-					newDoc[key] = e.target.checked;
 					newDoc["displayUnit"] = null;
-				} else {
-					newDoc[key] = e.target.checked;
 				}
+				newDoc[key] = e.target.checked;
 
 				this.onDocChange(this, oldDoc, newDoc);
 			},

--- a/app/js/app/directives/react_classes/QuestionBlock.js
+++ b/app/js/app/directives/react_classes/QuestionBlock.js
@@ -469,8 +469,11 @@ define(["react", "jquery"], function(React,$) {
 										<div className="small-3 columns">
 											<input type="text" value={this.props.doc.displayUnit} onChange={this.onDisplayUnitChange}/>
 										</div>
-										<div ref="requireUnitsCheckbox" className="small-6 columns">
-											<label><input type="checkbox" checked={this.props.doc.requireUnits} onChange={this.onCheckboxChange.bind(this, "requireUnits")} />Require Units</label>
+										<div className="small-1 columns">
+											OR
+										</div>
+										<div ref="requireUnitsCheckbox" className="small-5 columns">
+											<label><input type="checkbox" checked={this.props.doc.requireUnits} onChange={this.onCheckboxChange.bind(this, "requireUnits")} />Require choice of units</label>
 										</div>
 									</div>
 


### PR DESCRIPTION
## Don't merge until API/APP changes are merged 
- Sets `displayUnit` to `null` initially, as `requireUnit` is `true` by default.
- If `displayUnit` has an entry that isn't an empty string then we set `requireUnits` to `false` and store the `displayUnit`.
- If `requireUnit` is checked we set `displayUnit` to `null`.