### PR TITLE
Field for default feedback on non-quick questions

### DIFF
--- a/app/js/app/directives/content_editor.js
+++ b/app/js/app/directives/content_editor.js
@@ -239,7 +239,7 @@ define([
 
 	var ChemicalFormulaChoiceBlock = _ChemicalFormulaChoiceBlock(ContentEditor, Block, ContentBlock);
 
-	var QuestionBlock = _QuestionBlock(ContentEditor, Block, VariantBlock, ContentChildren, ContentValueOrChildren, TabsBlock, ParsonsItemBlock, ParsonsChoiceBlock);
+	var QuestionBlock = _QuestionBlock(ContentEditor, Block, VariantBlock, ContentChildren, ContentValue, ContentValueOrChildren, TabsBlock, ParsonsItemBlock, ParsonsChoiceBlock);
 
 	var GlossaryTermBlock = _GlossaryTermBlock(ContentEditor, Block, Tags, ContentBlock);
 

--- a/app/js/app/directives/react_classes/QuestionBlock.js
+++ b/app/js/app/directives/react_classes/QuestionBlock.js
@@ -461,7 +461,7 @@ define(["react", "jquery"], function(React,$) {
 				if (this.props.doc.type != "isaacQuestion") {
 					var defaultFeedback = <Block type="content" blockTypeTitle="Default Feedback">
 						{/*<ContentValue value={(this.props.doc.defaultFeedback && this.props.doc.defaultFeedback.value) || "_Enter default feedback here_"} encoding="markdown" onChange={this.onDefaultFeedbackChange} />*/}
-						<ContentValueOrChildren children={(this.props.doc.defaultFeedback && this.props.doc.defaultFeedback.children) || []} encoding="markdown" onChange={this.onDefaultFeedbackChange} />
+						<ContentChildren items={(this.props.doc.defaultFeedback && this.props.doc.defaultFeedback.children) || []} encoding="markdown" onChange={this.onDefaultFeedbackChange} />
 					</Block>;
 				}
 

--- a/app/js/app/directives/react_classes/QuestionBlock.js
+++ b/app/js/app/directives/react_classes/QuestionBlock.js
@@ -64,10 +64,19 @@ define(["react", "jquery"], function(React,$) {
 				this.onDocChange(this, oldDoc, newDoc);
 			},
 
-			onDefaultFeedbackChange: function(c, oldDefaultFeedbackDoc, newDefaultFeedbackDoc) {
+			onDefaultFeedbackChange: function(e) {
 				var oldDoc = this.props.doc;
 				var newDoc = $.extend({}, oldDoc);
-				newDoc.defaultFeedback = newDefaultFeedbackDoc;
+
+				if (!e.target.value.replace(/\s/g, '').length) {
+					newDoc.defaultFeedback = null;
+				} else {
+					newDoc.defaultFeedback = {
+						"type": "content",
+						"value": e.target.value,
+						"encoding": "markdown"
+					};
+				}
 
 				this.onDocChange(this, oldDoc, newDoc);
 			},
@@ -126,6 +135,13 @@ define(["react", "jquery"], function(React,$) {
 					delete newDoc.requireUnits;
 					// Remove the randomiseChoices property as it is no longer applicable to this type of question
 					delete newDoc.randomiseChoices;
+				}
+
+				if (newType != "isaacQuestion" && !newDoc.hasOwnProperty("defaultFeedback")) {
+					newDoc.defaultFeedback = null;
+				} else {
+					// Remove the defaultFeedback property as it is not applicable to quick questions
+					delete newDoc.defaultFeedback;
 				}
 
 				this.onDocChange(this, oldDoc, newDoc);
@@ -426,11 +442,16 @@ define(["react", "jquery"], function(React,$) {
 				}
 
 				if (this.props.doc.type != "isaacQuestion") {
+					var defaultFeedbackVal = "";
+					if (this.props.doc.defaultFeedback != null && this.props.doc.defaultFeedback.value) {
+						defaultFeedbackVal = this.props.doc.defaultFeedback.value;
+					}
+
 					var defaultFeedback = <div className="row">
 						<div className="large-12 columns">
-							<div className="question-default-feedback"><VariantBlock blockTypeTitle="DefaultFeedback" doc={this.props.doc.defaultFeedback} onChange={this.onDefaultFeedbackChange}/></div>
+							<label>Default feedback <input value={defaultFeedbackVal} placeholder="Enter default feedback here" onChange={this.onDefaultFeedbackChange}/></label>
 						</div>
-					</div>
+					</div>;
 				}
 
 				return (

--- a/app/js/app/directives/react_classes/QuestionBlock.js
+++ b/app/js/app/directives/react_classes/QuestionBlock.js
@@ -64,6 +64,14 @@ define(["react", "jquery"], function(React,$) {
 				this.onDocChange(this, oldDoc, newDoc);
 			},
 
+			onDefaultFeedbackChange: function(c, oldDefaultFeedbackDoc, newDefaultFeedbackDoc) {
+				var oldDoc = this.props.doc;
+				var newDoc = $.extend({}, oldDoc);
+				newDoc.defaultFeedback = newDefaultFeedbackDoc;
+
+				this.onDocChange(this, oldDoc, newDoc);
+			},
+
 			onSignificantFiguresMinChange: function(e) {
 
 				this.setState({
@@ -417,6 +425,14 @@ define(["react", "jquery"], function(React,$) {
 					</div>
 				}
 
+				if (this.props.doc.type != "isaacQuestion") {
+					var defaultFeedback = <div className="row">
+						<div className="large-12 columns">
+							<div className="question-default-feedback"><VariantBlock blockTypeTitle="DefaultFeedback" doc={this.props.doc.defaultFeedback} onChange={this.onDefaultFeedbackChange}/></div>
+						</div>
+					</div>
+				}
+
 				return (
 					<Block type="question" blockTypeTitle="Question" doc={this.props.doc} onChange={this.onDocChange}>
 						<form>
@@ -485,6 +501,7 @@ define(["react", "jquery"], function(React,$) {
 						{parsonsItemsList}
 						{choices}
 						{freeTextHelpTable}
+						{defaultFeedback}
 						<div className="row">
 							<div className="large-12 columns">
 								<div className="question-answer"><VariantBlock blockTypeTitle="Answer" doc={this.props.doc.answer} onChange={this.onAnswerChange}/></div>

--- a/app/js/app/directives/react_classes/QuestionBlock.js
+++ b/app/js/app/directives/react_classes/QuestionBlock.js
@@ -64,16 +64,33 @@ define(["react", "jquery"], function(React,$) {
 				this.onDocChange(this, oldDoc, newDoc);
 			},
 
-			onDefaultFeedbackChange: function(e, oldDefaultFeedbackValue, newDefaultFeedbackValue) {
+			// onDefaultFeedbackChange: function(e, oldDefaultFeedbackValue, newDefaultFeedbackValue) {
+			// 	var oldDoc = this.props.doc;
+			// 	var newDoc = $.extend({}, oldDoc);
+			//
+			// 	if (newDefaultFeedbackValue.replace(/\s/gm, '').length === 0) {
+			// 		delete newDoc.defaultFeedback;
+			// 	} else {
+			// 		newDoc.defaultFeedback = {
+			// 			"type": "content",
+			// 			"value": newDefaultFeedbackValue,
+			// 			"encoding": "markdown"
+			// 		};
+			// 	}
+			//
+			// 	this.onDocChange(this, oldDoc, newDoc);
+			// },
+
+			onDefaultFeedbackChange: function(e, oldDefaultFeedbackChildren, newDefaultFeedbackChildren) {
 				var oldDoc = this.props.doc;
 				var newDoc = $.extend({}, oldDoc);
 
-				if (newDefaultFeedbackValue.replace(/\s/gm, '').length === 0) {
+				if (newDefaultFeedbackChildren.length === 0) {
 					delete newDoc.defaultFeedback;
 				} else {
 					newDoc.defaultFeedback = {
 						"type": "content",
-						"value": newDefaultFeedbackValue,
+						"children": newDefaultFeedbackChildren,
 						"encoding": "markdown"
 					};
 				}
@@ -443,7 +460,8 @@ define(["react", "jquery"], function(React,$) {
 
 				if (this.props.doc.type != "isaacQuestion") {
 					var defaultFeedback = <Block type="content" blockTypeTitle="Default Feedback">
-						<ContentValue value={(this.props.doc.defaultFeedback && this.props.doc.defaultFeedback.value) || "_Enter default feedback here_"} encoding="markdown" onChange={this.onDefaultFeedbackChange} />
+						{/*<ContentValue value={(this.props.doc.defaultFeedback && this.props.doc.defaultFeedback.value) || "_Enter default feedback here_"} encoding="markdown" onChange={this.onDefaultFeedbackChange} />*/}
+						<ContentValueOrChildren children={(this.props.doc.defaultFeedback && this.props.doc.defaultFeedback.children) || []} encoding="markdown" onChange={this.onDefaultFeedbackChange} />
 					</Block>;
 				}
 

--- a/app/js/app/directives/react_classes/QuestionBlock.js
+++ b/app/js/app/directives/react_classes/QuestionBlock.js
@@ -1,5 +1,5 @@
 define(["react", "jquery"], function(React,$) {
-	return function(ContentEditor, Block, VariantBlock, ContentChildren, ContentValueOrChildren, TabsBlock, ParsonsItemBlock, ParsonsChoiceBlock) {
+	return function(ContentEditor, Block, VariantBlock, ContentChildren, ContentValue, ContentValueOrChildren, TabsBlock, ParsonsItemBlock, ParsonsChoiceBlock) {
 		return React.createClass({
 
 			getInitialState: function() {
@@ -64,16 +64,16 @@ define(["react", "jquery"], function(React,$) {
 				this.onDocChange(this, oldDoc, newDoc);
 			},
 
-			onDefaultFeedbackChange: function(e) {
+			onDefaultFeedbackChange: function(e, oldDefaultFeedbackValue, newDefaultFeedbackValue) {
 				var oldDoc = this.props.doc;
 				var newDoc = $.extend({}, oldDoc);
 
-				if (!e.target.value.replace(/\s/gm, '').length) {
-					newDoc.defaultFeedback = null;
+				if (newDefaultFeedbackValue.replace(/\s/gm, '').length === 0) {
+					delete newDoc.defaultFeedback;
 				} else {
 					newDoc.defaultFeedback = {
 						"type": "content",
-						"value": e.target.value,
+						"value": newDefaultFeedbackValue,
 						"encoding": "markdown"
 					};
 				}
@@ -442,14 +442,9 @@ define(["react", "jquery"], function(React,$) {
 				}
 
 				if (this.props.doc.type != "isaacQuestion") {
-					var defaultFeedbackVal = "";
-					if (this.props.doc.defaultFeedback != null && this.props.doc.defaultFeedback.value) {
-						defaultFeedbackVal = this.props.doc.defaultFeedback.value;
-					}
-
-					var defaultFeedback = <label>Default feedback
-						<textarea value={defaultFeedbackVal} placeholder="Enter default feedback here" onChange={this.onDefaultFeedbackChange}/>
-					</label>
+					var defaultFeedback = <Block type="content" blockTypeTitle="Default Feedback">
+						<ContentValue value={(this.props.doc.defaultFeedback && this.props.doc.defaultFeedback.value) || "_Enter default feedback here_"} encoding="markdown" onChange={this.onDefaultFeedbackChange} />
+					</Block>;
 				}
 
 				return (

--- a/app/js/app/directives/react_classes/QuestionBlock.js
+++ b/app/js/app/directives/react_classes/QuestionBlock.js
@@ -64,28 +64,11 @@ define(["react", "jquery"], function(React,$) {
 				this.onDocChange(this, oldDoc, newDoc);
 			},
 
-			// onDefaultFeedbackChange: function(e, oldDefaultFeedbackValue, newDefaultFeedbackValue) {
-			// 	var oldDoc = this.props.doc;
-			// 	var newDoc = $.extend({}, oldDoc);
-			//
-			// 	if (newDefaultFeedbackValue.replace(/\s/gm, '').length === 0) {
-			// 		delete newDoc.defaultFeedback;
-			// 	} else {
-			// 		newDoc.defaultFeedback = {
-			// 			"type": "content",
-			// 			"value": newDefaultFeedbackValue,
-			// 			"encoding": "markdown"
-			// 		};
-			// 	}
-			//
-			// 	this.onDocChange(this, oldDoc, newDoc);
-			// },
-
 			onDefaultFeedbackChange: function(e, oldDefaultFeedbackChildren, newDefaultFeedbackChildren) {
 				var oldDoc = this.props.doc;
 				var newDoc = $.extend({}, oldDoc);
 
-				if (newDefaultFeedbackChildren.length === 0) {
+				if (!newDefaultFeedbackChildren || newDefaultFeedbackChildren.length === 0) {
 					delete newDoc.defaultFeedback;
 				} else {
 					newDoc.defaultFeedback = {
@@ -460,7 +443,6 @@ define(["react", "jquery"], function(React,$) {
 
 				if (this.props.doc.type != "isaacQuestion") {
 					var defaultFeedback = <Block type="content" blockTypeTitle="Default Feedback">
-						{/*<ContentValue value={(this.props.doc.defaultFeedback && this.props.doc.defaultFeedback.value) || "_Enter default feedback here_"} encoding="markdown" onChange={this.onDefaultFeedbackChange} />*/}
 						<ContentChildren items={(this.props.doc.defaultFeedback && this.props.doc.defaultFeedback.children) || []} encoding="markdown" onChange={this.onDefaultFeedbackChange} />
 					</Block>;
 				}

--- a/app/js/app/directives/react_classes/QuestionBlock.js
+++ b/app/js/app/directives/react_classes/QuestionBlock.js
@@ -68,7 +68,7 @@ define(["react", "jquery"], function(React,$) {
 				var oldDoc = this.props.doc;
 				var newDoc = $.extend({}, oldDoc);
 
-				if (!e.target.value.replace(/\s/g, '').length) {
+				if (!e.target.value.replace(/\s/gm, '').length) {
 					newDoc.defaultFeedback = null;
 				} else {
 					newDoc.defaultFeedback = {
@@ -447,11 +447,9 @@ define(["react", "jquery"], function(React,$) {
 						defaultFeedbackVal = this.props.doc.defaultFeedback.value;
 					}
 
-					var defaultFeedback = <div className="row">
-						<div className="large-12 columns">
-							<label>Default feedback <input value={defaultFeedbackVal} placeholder="Enter default feedback here" onChange={this.onDefaultFeedbackChange}/></label>
-						</div>
-					</div>;
+					var defaultFeedback = <label>Default feedback
+						<textarea value={defaultFeedbackVal} placeholder="Enter default feedback here" onChange={this.onDefaultFeedbackChange}/>
+					</label>
 				}
 
 				return (
@@ -522,7 +520,11 @@ define(["react", "jquery"], function(React,$) {
 						{parsonsItemsList}
 						{choices}
 						{freeTextHelpTable}
-						{defaultFeedback}
+						<div className="row">
+							<div className="large-12 columns">
+								{defaultFeedback}
+							</div>
+						</div>
 						<div className="row">
 							<div className="large-12 columns">
 								<div className="question-answer"><VariantBlock blockTypeTitle="Answer" doc={this.props.doc.answer} onChange={this.onAnswerChange}/></div>

--- a/app/snippets/content_templates/isaacQuestion.json
+++ b/app/snippets/content_templates/isaacQuestion.json
@@ -5,12 +5,7 @@
 	"choices": [],
 	"answer": {
 		"type": "content",
-		"value": "_Enter answer here_", 
-		"encoding": "markdown"
-	},
-	"defaultFeedback": {
-		"type": "content",
-		"value": "_Enter default feedback here_",
+		"value": "_Enter answer here_",
 		"encoding": "markdown"
 	}
 }

--- a/app/snippets/content_templates/isaacQuestion.json
+++ b/app/snippets/content_templates/isaacQuestion.json
@@ -7,5 +7,10 @@
 		"type": "content",
 		"value": "_Enter answer here_", 
 		"encoding": "markdown"
+	},
+	"defaultFeedback": {
+		"type": "content",
+		"value": "_Enter default feedback here_",
+		"encoding": "markdown"
 	}
 }


### PR DESCRIPTION
This adds a text area for default feedback on all question types except quick ones.

It had to be a `textarea` and not a markdown `Block`/`VariantBlock` because those re-render based on
changes to the JSON. If the default feedback input is empty the `defaultFeedback` field in the JSON needed
to be set to `null`, but if I used a content `Block` to input it with (as with the `answer` field), `null`-ing the 
associated field would remove the ability to write text in the content block. 

Either it needed another kind of content block that wasn't so closely tied to the underlying JSON, or a
textarea/input. 

UPDATE: I found the block I was looking for - the input is no longer a `textarea` and is now instead a `ContentValue` 