### PR TITLE
Add 'exact answers only' option for numerical question builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ Files can be browsed from the menu on the left, and edited by clicking on them. 
 
 #### Developing the Content Editor
 
-To develop the content editor: check out this repo, run `npm start`, and then visit `localhost:8421` in a web browser.
-To update the css run `npm run sass`.
+To develop the content editor: 
+* Check out this repo
+* Run `npm run sass` to generate the CSS
+* Run via `npm start`, and then visit `localhost:8421` in a web browser
 
 You may find it useful to edit [`github_application.js`](app/js/app/github_application.js) to change the OAuth settings, or to alter the remote repository the editor connects to in [`services.js`](app/js/app/services.js). Both of these are configured on a per-hostname basis.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,6 @@ Files can be browsed from the menu on the left, and edited by clicking on them. 
 #### Developing the Content Editor
 
 To develop the content editor: check out this repo, run `npm start`, and then visit `localhost:8421` in a web browser.
-To update the css run `npx grunt`.
+To update the css run `npm run sass`.
 
 You may find it useful to edit [`github_application.js`](app/js/app/github_application.js) to change the OAuth settings, or to alter the remote repository the editor connects to in [`services.js`](app/js/app/services.js). Both of these are configured on a per-hostname basis.

--- a/app/js/app/directives/react_classes/QuestionBlock.js
+++ b/app/js/app/directives/react_classes/QuestionBlock.js
@@ -142,22 +142,27 @@ define(["react", "jquery"], function(React,$) {
 					// Add the default value if it is missing
 					newDoc.requireUnits = true;
 					newDoc.displayUnit = null;
+					newDoc.disregardSignificantFigures = false;
 					delete newDoc.showConfidence;
 					delete newDoc.randomiseChoices;
 				} else if (newType == "isaacQuestion" && !newDoc.hasOwnProperty("showConfidence")) {
 					newDoc.showConfidence = false;
 					delete newDoc.requireUnits
+					delete newDoc.disregardSignificantFigures
 					delete newDoc.displayUnit;
 					delete newDoc.randomiseChoices
 				} else if (newType == "isaacMultiChoiceQuestion" && !newDoc.hasOwnProperty("randomiseChoices")) {
 					// Add the default value if it is missing
 					newDoc.randomiseChoices = true;
 					delete newDoc.requireUnits
+					delete newDoc.disregardSignificantFigures
 					delete newDoc.displayUnit;
 					delete newDoc.showConfidence
 				} else {
 					// Remove the requireUnits property as it is no longer applicable to this type of question
 					delete newDoc.requireUnits;
+					// Remove the disregardSignificantFigures property as it is no longer applicable to this type of question
+					delete newDoc.disregardSignificantFigures;
 					// Remove the displayUnit property as it is no longer applicable to this type of question
 					delete newDoc.displayUnit;
 					// Remove the randomiseChoices property as it is no longer applicable to this type of question
@@ -508,21 +513,43 @@ define(["react", "jquery"], function(React,$) {
 							<div className="row">
 								<div className="small-6 columns">
 									<input type="text" value={this.props.doc.title || ""} onChange={this.onTitleChange} placeholder="Question title"/>
+								</div>
+								<div className="small-6 columns">
+									<select value={this.props.doc.type} onChange={this.type_Change}>
+										<option value="isaacQuestion">Quick Question</option>
+										<option value="isaacMultiChoiceQuestion">Multiple Choice Question</option>
+										<option value="isaacNumericQuestion">Numeric Question</option>
+										<option value="isaacSymbolicQuestion">Symbolic Question</option>
+										<option value="isaacStringMatchQuestion">String Match Question</option>
+										<option value="isaacRegexMatchQuestion">Regex Match Question</option>
+										<option value="isaacFreeTextQuestion">Free Text Question</option>
+										<option value="isaacSymbolicLogicQuestion">Logic Question</option>
+										<option value="isaacItemQuestion">Item Question</option>
+										<option value="isaacParsonsQuestion">Parsons Question</option>
+										<option value="isaacClozeQuestion">Cloze (Drag and Drop) Question</option>
+										<option value="isaacSymbolicChemistryQuestion">Chemistry Question</option>
+										<option value="isaacGraphSketcherQuestion">Graph Sketcher Question</option>
+									</select>
+								</div>
+								<div className="row">
 									<div className="row" style={{display: this.props.doc.type == "isaacNumericQuestion" ? "block" : "none"}}>
-										<div className="small-6 columns text-right">
+										<div className="small-3 columns text-right">
 											Significant figures:
 										</div>
-										<div className="small-1 columns text-right">
-											Min
+										<div className="small-2 columns">
+											<input type="text" placeholder="Min" value={this.state.significantFiguresMin} onChange={this.onSignificantFiguresMinChange}/>
+										</div>
+										<div className="small-1 columns">
+											to
 										</div>
 										<div className="small-2 columns">
-											<input type="text" value={this.state.significantFiguresMin} onChange={this.onSignificantFiguresMinChange}/>
+											<input type="text" placeholder="Max" value={this.state.significantFiguresMax} onChange={this.onSignificantFiguresMaxChange}/>
 										</div>
-										<div className="small-1 columns text-right">
-											Max
+										<div className="small-1 columns">
+											OR
 										</div>
-										<div className="small-2 columns">
-											<input type="text" value={this.state.significantFiguresMax} onChange={this.onSignificantFiguresMaxChange}/>
+										<div ref="disregardSigFigsCheckbox" className="small-3 columns">
+											<label><input type="checkbox" checked={this.props.doc.disregardSignificantFigures} onChange={this.onCheckboxChange.bind(this, "disregardSignificantFigures")} />Exact answers only</label>
 										</div>
 									</div>
 									<div className="row" style={{display: this.props.doc.type == "isaacNumericQuestion" ? "block" : "none"}}>
@@ -560,23 +587,6 @@ define(["react", "jquery"], function(React,$) {
 											<label><input type="checkbox" checked={this.props.doc.disableIndentation} onChange={this.onCheckboxChange.bind(this, "disableIndentation")} /> Disable indentation</label>
 										</div>
 									</div>
-								</div>
-								<div className="small-6 columns">
-									<select value={this.props.doc.type} onChange={this.type_Change}>
-										<option value="isaacQuestion">Quick Question</option>
-										<option value="isaacMultiChoiceQuestion">Multiple Choice Question</option>
-										<option value="isaacNumericQuestion">Numeric Question</option>
-										<option value="isaacSymbolicQuestion">Symbolic Question</option>
-										<option value="isaacStringMatchQuestion">String Match Question</option>
-										<option value="isaacRegexMatchQuestion">Regex Match Question</option>
-										<option value="isaacFreeTextQuestion">Free Text Question</option>
-										<option value="isaacSymbolicLogicQuestion">Logic Question</option>
-										<option value="isaacItemQuestion">Item Question</option>
-										<option value="isaacParsonsQuestion">Parsons Question</option>
-										<option value="isaacClozeQuestion">Cloze (Drag and Drop) Question</option>
-										<option value="isaacSymbolicChemistryQuestion">Chemistry Question</option>
-                    					<option value="isaacGraphSketcherQuestion">Graph Sketcher Question</option>
-									</select>
 								</div>
 								<div className="row" style={{display: this.props.doc.type == "isaacClozeQuestion" ? "block" : "none"}}>
 									<div ref="withReplacementCheckbox" className="small-6 small-offset-6 columns">


### PR DESCRIPTION
Also changes the question type and name to be two columns of the same row, as opposed to the first rows of two different side-by-side columns which limited the width of the question options below.